### PR TITLE
Update post controller to account for 'user_id' instead of 'user' column in DB

### DIFF
--- a/server/controllers/post_controller.js
+++ b/server/controllers/post_controller.js
@@ -7,8 +7,9 @@ posts.get('/', async (req, res) => {
     client.query(sql, [], (err, result) => {
         if (err) {
             return console.error(err.message);
+        } else {
+            res.status(200).json(result.rows)
         }
-        res.status(200).json(result.rows)
     })
     client.end;
 })
@@ -20,8 +21,9 @@ posts.get('/:id', async (req, res) => {
     client.query(sql, [id], (err, result) => {
         if (err) {
             return console.error(err.message);
+        } else {
+            res.status(200).json(result.rows)
         }
-        res.status(200).json(result.rows)
     })
     client.end;
 })
@@ -35,15 +37,16 @@ posts.post('/', async (req, res) => {
     client.query(sql, [file, tag, user_id], (err, result) => {
         if (err) {
             return console.error(err.message);
+        } else {
+            res.status(200).json({
+                message: 'Successfully created post'
+            })
         }
-        res.status(200).json({
-            message: 'Successfully created post'
-        })
     })
     client.end;
 })
 
-// edit a post
+// update a post
 posts.put('/:id', async (req, res) => {
   const post_id = req.params.id
   const file = req.body.file
@@ -53,10 +56,11 @@ posts.put('/:id', async (req, res) => {
   client.query(sql, [file, tag, user_id, post_id], (err, result) => {
       if (err) {
           return console.error(err.message);
+      } else {
+        res.status(202).json({
+            message: 'Post successfully updated'
+          })
       }
-      res.status(202).json({
-        message: 'Post successfully updated'
-      })
   })
   client.end;
 })
@@ -68,10 +72,11 @@ posts.delete('/:id', async (req, res) => {
   client.query(sql, [id], (err, result) => {
       if (err) {
           return console.error(err.message);
+      } else {
+        res.status(200).json({
+            message: 'Post successfully deleted'
+          })
       }
-      res.status(200).json({
-        message: 'Post successfully deleted'
-      })
   })
   client.end;
 })

--- a/server/controllers/post_controller.js
+++ b/server/controllers/post_controller.js
@@ -28,11 +28,11 @@ posts.get('/:id', async (req, res) => {
 
 // create a post
 posts.post('/', async (req, res) => {
-    const name = req.body.name
     const file = req.body.file
     const tag = req.body.tag
-    let sql = 'INSERT INTO posts(post_id, name, file, tag) VALUES(DEFAULT, $1, $2, $3)'
-    client.query(sql, [name, file, tag], (err, result) => {
+    const user_id = req.body.user_id
+    let sql = 'INSERT INTO posts(post_id, file, tag, user_id) VALUES(DEFAULT, $1, $2, $3)'
+    client.query(sql, [file, tag, user_id], (err, result) => {
         if (err) {
             return console.error(err.message);
         }
@@ -45,12 +45,12 @@ posts.post('/', async (req, res) => {
 
 // edit a post
 posts.put('/:id', async (req, res) => {
-  const id = req.params.id
-  const name = req.body.name
+  const post_id = req.params.id
   const file = req.body.file
   const tag = req.body.tag
-  let sql = "UPDATE posts SET name = $1, file = $2, tag = $3 WHERE post_id = $5"
-  client.query(sql, [name, file, tag, id], (err, result) => {
+  const user_id = req.body.user_id
+  let sql = "UPDATE posts SET file = $1, tag = $2, user_id = $3 WHERE post_id = $4"
+  client.query(sql, [file, tag, user_id, post_id], (err, result) => {
       if (err) {
           return console.error(err.message);
       }
@@ -64,7 +64,7 @@ posts.put('/:id', async (req, res) => {
 // delete a post
 posts.delete('/:id', async (req, res) => {
   id = req.params.id
-  let sql = "DELETE FROM post WHERE post_id = $1"
+  let sql = "DELETE FROM posts WHERE post_id = $1"
   client.query(sql, [id], (err, result) => {
       if (err) {
           return console.error(err.message);


### PR DESCRIPTION
Update controller to account for `user_id` instead of `user` on target `posts` database since `user` column field name failed for requests.

The column name as `user` in the database instead of `user_id` would return this error each time the insert was run upon POST:

```
syntax error at or near "user"
```

The model for the `posts` DB also should be updated with this column name to isolate any similar issues. I did modify the column name directly in ElephantSQL to `user_id` (since it is an integer value) and tested all posts endpoints through Postman locally as well.